### PR TITLE
Reworks Station Objectives Selection

### DIFF
--- a/code/_globalvars/game_modes.dm
+++ b/code/_globalvars/game_modes.dm
@@ -7,6 +7,10 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 GLOBAL_VAR_INIT(wavesecret, 0) //! meteor mode, delays wave progression, terrible name
 GLOBAL_DATUM(start_state, /datum/station_state) //! Used in round-end report
 
+GLOBAL_VAR_INIT(station_goal_selection_open, FALSE) //Stores whether the station goal selection menu is open.
+GLOBAL_VAR(selected_station_goal) //Stores the currently selected station goal. Initialized to null by default.
+
+
 //TODO clear this one up too
 GLOBAL_DATUM(cult_narsie, /obj/eldritch/narsie)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks the way Station Objectives are assigned, instead of it being fully random, gives heads of staff a way to coordinate with the station on which objective they wish to attempt to complete that shift, if no answer is provided within a time frame, it automatically chooses one as it previously was

## Why It's Good For The Game

Some station objectives are not fun to complete, let's give command a way to coordinate with the station to choose an objective to complete that shift, hopefully makes objectives be completed more often.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


![image](https://github.com/user-attachments/assets/82af45d3-d423-4a84-bfba-a83a11b00417)

![image1](https://github.com/user-attachments/assets/5e4ea22a-232b-487f-a6d7-e99558483b74)

If someone attempts to choose an objective after the window has passed, they're met with this comment

![image](https://github.com/user-attachments/assets/a55f4d40-3fb7-4bf5-b200-37fa6cecc4b0)


</details>

## Changelog
:cl: Isaacnml

tweak: Tweaks how station objective selection works

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
